### PR TITLE
Harden Binance perpetual bot runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,3 +76,18 @@ BACKUP_RETENTION_DAYS=30
 # Generate secure secret with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 TRADINGVIEW_WEBHOOK_SECRET=your-tradingview-webhook-secret-key
 API_BASE_URL=http://localhost:8000
+
+# Binance USDT Perpetual Multi-Strategy Bot
+BOT_BINANCE_API_KEY=your-binance-futures-api-key
+BOT_BINANCE_API_SECRET=your-binance-futures-api-secret
+BOT_SYMBOLS='["BTC/USDT:USDT","ETH/USDT:USDT"]'
+BOT_FIXED_NOTIONAL_USDT=100
+BOT_MAX_CORRELATION=0.65
+BOT_WEBSOCKET_TIMEOUT_SECONDS=30
+BOT_HEARTBEAT_INTERVAL_SECONDS=15
+BOT_MAX_RECONNECT_BACKOFF_SECONDS=60
+BOT_INTERNAL_PORT=22022
+BOT_LEVERAGE=3
+BOT_DATABASE_URL=postgresql://abtuser:abtpassword@postgres:5432/abtpro_db
+BOT_ML_MODEL_PATH=/models/xgb_trade_gate.json
+BOT_DRY_RUN=true

--- a/apps/backend/src/binance_perp_bot/config.py
+++ b/apps/backend/src/binance_perp_bot/config.py
@@ -1,28 +1,44 @@
 from __future__ import annotations
 
-from pydantic import Field, PostgresDsn, SecretStr
+from pydantic import Field, PostgresDsn, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class BotConfig(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_prefix="BOT_", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_prefix="BOT_", extra="ignore"
+    )
 
     binance_api_key: SecretStr = Field(..., description="Binance Futures API key")
     binance_api_secret: SecretStr = Field(..., description="Binance Futures API secret")
-    symbols: list[str] = Field(default_factory=lambda: ["BTC/USDT:USDT", "ETH/USDT:USDT"])
+    symbols: list[str] = Field(
+        default_factory=lambda: ["BTC/USDT:USDT", "ETH/USDT:USDT"]
+    )
     fixed_notional_usdt: float = Field(default=100.0, gt=0)
     max_correlation: float = Field(default=0.65, gt=0, lt=1)
     websocket_timeout_seconds: float = Field(default=30.0, gt=0)
     heartbeat_interval_seconds: float = Field(default=15.0, gt=0)
     max_reconnect_backoff_seconds: float = Field(default=60.0, gt=1)
-    internal_port: int = Field(default=22022, description="Spaceship Standard port for internal comms or SSH tunnels")
+    internal_port: int = Field(
+        default=22022,
+        description="Spaceship Standard port for internal comms or SSH tunnels",
+    )
     leverage: int = Field(default=3, ge=1, le=20)
-    database_url: PostgresDsn = Field(default="postgresql://postgres:postgres@postgres:5432/abtp")
+    database_url: PostgresDsn = Field(
+        default="postgresql://postgres:postgres@postgres:5432/abtp"
+    )
     ml_model_path: str = Field(default="/models/xgb_trade_gate.json")
     dry_run: bool = True
 
 
 class AllocationConfig(BaseSettings):
-    scalp: float = 0.20
-    swing: float = 0.30
-    position: float = 0.50
+    scalp: float = Field(default=0.20, ge=0, le=1)
+    swing: float = Field(default=0.30, ge=0, le=1)
+    position: float = Field(default=0.50, ge=0, le=1)
+
+    @model_validator(mode="after")
+    def validate_total_allocation(self) -> "AllocationConfig":
+        total = self.scalp + self.swing + self.position
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError("strategy allocations must sum to 1.0")
+        return self

--- a/apps/backend/src/binance_perp_bot/db/timescale.py
+++ b/apps/backend/src/binance_perp_bot/db/timescale.py
@@ -6,9 +6,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 import psycopg2
-from psycopg2.extras import Json
-
 from binance_perp_bot.models import MarketSnapshot, TradeSignal
+from psycopg2 import errors
+from psycopg2.extras import Json
 
 
 class TimescaleJournal:
@@ -21,7 +21,9 @@ class TimescaleJournal:
     async def write_ohlcv(self, snapshot: MarketSnapshot) -> None:
         await asyncio.to_thread(self._write_ohlcv_sync, snapshot)
 
-    async def write_signal(self, signal: TradeSignal, status: str, payload: dict[str, Any]) -> None:
+    async def write_signal(
+        self, signal: TradeSignal, status: str, payload: dict[str, Any]
+    ) -> None:
         await asyncio.to_thread(self._write_signal_sync, signal, status, payload)
 
     def _connect(self):
@@ -29,7 +31,12 @@ class TimescaleJournal:
 
     def _migrate_sync(self) -> None:
         with self._connect() as conn, conn.cursor() as cur:
-            cur.execute("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE")
+            timescale_enabled = True
+            try:
+                cur.execute("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE")
+            except (errors.InsufficientPrivilege, errors.UndefinedFile):
+                conn.rollback()
+                timescale_enabled = False
             cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS ohlcv (
@@ -45,7 +52,10 @@ class TimescaleJournal:
                 )
                 """
             )
-            cur.execute("SELECT create_hypertable('ohlcv', 'time', if_not_exists => TRUE)")
+            if timescale_enabled:
+                cur.execute(
+                    "SELECT create_hypertable('ohlcv', 'time', if_not_exists => TRUE)"
+                )
             cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS trade_journal (
@@ -59,14 +69,20 @@ class TimescaleJournal:
                 )
                 """
             )
-            cur.execute("SELECT create_hypertable('trade_journal', 'time', if_not_exists => TRUE)")
+            if timescale_enabled:
+                cur.execute(
+                    "SELECT create_hypertable("
+                    "'trade_journal', 'time', if_not_exists => TRUE)"
+                )
 
     def _write_ohlcv_sync(self, snapshot: MarketSnapshot) -> None:
         rows = self._rows(snapshot)
         with self._connect() as conn, conn.cursor() as cur:
             cur.executemany(
                 """
-                INSERT INTO ohlcv (time, symbol, timeframe, open, high, low, close, volume)
+                INSERT INTO ohlcv (
+                    time, symbol, timeframe, open, high, low, close, volume
+                )
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (time, symbol, timeframe) DO UPDATE SET
                     open = EXCLUDED.open, high = EXCLUDED.high, low = EXCLUDED.low,
@@ -75,14 +91,25 @@ class TimescaleJournal:
                 rows,
             )
 
-    def _write_signal_sync(self, signal: TradeSignal, status: str, payload: dict[str, Any]) -> None:
+    def _write_signal_sync(
+        self, signal: TradeSignal, status: str, payload: dict[str, Any]
+    ) -> None:
         with self._connect() as conn, conn.cursor() as cur:
             cur.execute(
                 """
-                INSERT INTO trade_journal (trace_id, symbol, strategy, action, status, payload)
+                INSERT INTO trade_journal (
+                    trace_id, symbol, strategy, action, status, payload
+                )
                 VALUES (%s, %s, %s, %s, %s, %s)
                 """,
-                (signal.trace_id, signal.symbol, signal.strategy.value, signal.action.value, status, Json(payload)),
+                (
+                    signal.trace_id,
+                    signal.symbol,
+                    signal.strategy.value,
+                    signal.action.value,
+                    status,
+                    Json(payload),
+                ),
             )
 
     def _rows(self, snapshot: MarketSnapshot) -> Iterable[tuple[Any, ...]]:

--- a/apps/backend/src/binance_perp_bot/execution/engine.py
+++ b/apps/backend/src/binance_perp_bot/execution/engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import numpy as np
 from binance_perp_bot.config import BotConfig
 from binance_perp_bot.db.timescale import TimescaleJournal
 from binance_perp_bot.execution.exchange import BinancePerpStream
@@ -34,6 +35,7 @@ class ExecutionEngine:
 
     async def on_snapshot(self, snapshot: MarketSnapshot) -> None:
         await self.journal.write_ohlcv(snapshot)
+        await self._update_return_history(snapshot)
         equity = await self.stream.fetch_equity_usdt()
         await self.position_manager.update_equity(equity)
         regime = self.regime_detector.detect(snapshot)
@@ -44,29 +46,57 @@ class ExecutionEngine:
             signal = strategy.check_signal(snapshot, regime)
             if signal is None:
                 continue
-            signal.size_usdt = strategy.calculate_size(snapshot, equity, self.config.fixed_notional_usdt)
-            signal.metadata.update({"price": price, "regime_suitability": strategy.get_regime_suitability(regime)})
-            extra = {"trace_id": signal.trace_id, "symbol": signal.symbol, "strategy": signal.strategy.value}
+            signal.size_usdt = strategy.calculate_size(
+                snapshot, equity, self.config.fixed_notional_usdt
+            )
+            signal.metadata.update(
+                {
+                    "price": price,
+                    "regime_suitability": strategy.get_regime_suitability(regime),
+                }
+            )
+            extra = {
+                "trace_id": signal.trace_id,
+                "symbol": signal.symbol,
+                "strategy": signal.strategy.value,
+            }
             if strategy.get_regime_suitability(regime) < 0.50:
-                await self.journal.write_signal(signal, "regime_rejected", signal.metadata)
+                await self.journal.write_signal(
+                    signal, "regime_rejected", signal.metadata
+                )
                 self.logger.info("signal_regime_rejected", extra=extra)
                 continue
             if not self.trade_gate.allow(snapshot, signal):
                 await self.journal.write_signal(signal, "ml_rejected", signal.metadata)
                 self.logger.info("signal_ml_rejected", extra=extra)
                 continue
-            intent = await self.position_manager.reserve(signal, price, self.config.leverage)
+            intent = await self.position_manager.reserve(
+                signal, price, self.config.leverage
+            )
             if intent is None:
-                await self.journal.write_signal(signal, "risk_rejected", signal.metadata)
+                await self.journal.write_signal(
+                    signal, "risk_rejected", signal.metadata
+                )
                 self.logger.info("signal_risk_rejected", extra=extra)
                 continue
             try:
                 order = await self.stream.execute(intent)
                 fill = float(order.get("average") or price)
                 await self.position_manager.commit_open(intent, fill)
-                await self.journal.write_signal(signal, "executed", {**signal.metadata, "order": order})
+                await self.journal.write_signal(
+                    signal, "executed", {**signal.metadata, "order": order}
+                )
                 self.logger.info("signal_executed", extra=extra)
             except Exception:
                 await self.position_manager.release(intent)
-                await self.journal.write_signal(signal, "execution_failed", signal.metadata)
+                await self.journal.write_signal(
+                    signal, "execution_failed", signal.metadata
+                )
                 self.logger.exception("signal_execution_failed", extra=extra)
+
+    async def _update_return_history(self, snapshot: MarketSnapshot) -> None:
+        closes = np.asarray([candle[4] for candle in snapshot.ohlcv], dtype=float)
+        if closes.size < 21:
+            return
+        returns = np.diff(closes) / np.maximum(closes[:-1], 1e-9)
+        await self.position_manager.set_return_history(snapshot.symbol, returns[-120:])

--- a/apps/backend/src/binance_perp_bot/execution/exchange.py
+++ b/apps/backend/src/binance_perp_bot/execution/exchange.py
@@ -6,7 +6,6 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import ccxt.pro as ccxtpro
-
 from binance_perp_bot.config import BotConfig
 from binance_perp_bot.models import MarketSnapshot, PositionIntent
 
@@ -17,65 +16,14 @@ class BinancePerpStream:
     def __init__(self, config: BotConfig, on_snapshot: SnapshotHandler) -> None:
         self.config = config
         self.on_snapshot = on_snapshot
-        self.exchange = ccxtpro.binanceusdm(
-            {
-                "apiKey": config.binance_api_key.get_secret_value(),
-                "secret": config.binance_api_secret.get_secret_value(),
-                "enableRateLimit": True,
-                "options": {"defaultType": "swap", "adjustForTimeDifference": True},
-            }
-        )
+        self.exchange = self._build_exchange()
         self.logger = logging.getLogger(__name__)
         self._stopping = asyncio.Event()
+        self._reconnect_lock = asyncio.Lock()
+        self._markets_loaded = False
 
-    async def close(self) -> None:
-        self._stopping.set()
-        await self.exchange.close()
-
-    async def stream_symbol(self, symbol: str, timeframe: str) -> None:
-        backoff = 1.0
-        while not self._stopping.is_set():
-            heartbeat_task = asyncio.create_task(self._heartbeat(symbol))
-            try:
-                await self.exchange.load_markets()
-                while not self._stopping.is_set():
-                    if heartbeat_task.done():
-                        heartbeat_task.result()
-                    orderbook_task = asyncio.create_task(self.exchange.watch_order_book(symbol, limit=20))
-                    ticker_task = asyncio.create_task(self.exchange.watch_ticker(symbol))
-                    done, pending = await asyncio.wait(
-                        {orderbook_task, ticker_task},
-                        timeout=self.config.websocket_timeout_seconds,
-                        return_when=asyncio.ALL_COMPLETED,
-                    )
-                    for task in pending:
-                        task.cancel()
-                    if pending or len(done) != 2:
-                        raise TimeoutError(f"WebSocket stalled for {symbol}")
-                    orderbook = orderbook_task.result()
-                    ticker = ticker_task.result()
-                    ohlcv = await self.exchange.fetch_ohlcv(symbol, timeframe=timeframe, limit=250)
-                    await self.on_snapshot(MarketSnapshot(symbol, timeframe, ohlcv, ticker, orderbook))
-                    backoff = 1.0
-            except (asyncio.CancelledError, KeyboardInterrupt):
-                raise
-            except Exception as exc:
-                self.logger.warning("websocket_reconnect", extra={"symbol": symbol, "trace_id": "stream", "strategy": timeframe}, exc_info=exc)
-                await self._recreate_exchange()
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2.0, self.config.max_reconnect_backoff_seconds)
-            finally:
-                heartbeat_task.cancel()
-
-    async def _heartbeat(self, symbol: str) -> None:
-        while not self._stopping.is_set():
-            await asyncio.sleep(self.config.heartbeat_interval_seconds)
-            await asyncio.wait_for(self.exchange.fetch_time(), timeout=10)
-            self.logger.info("websocket_heartbeat_ok", extra={"symbol": symbol, "trace_id": "heartbeat", "strategy": "stream"})
-
-    async def _recreate_exchange(self) -> None:
-        await self.exchange.close()
-        self.exchange = ccxtpro.binanceusdm(
+    def _build_exchange(self):
+        return ccxtpro.binanceusdm(
             {
                 "apiKey": self.config.binance_api_key.get_secret_value(),
                 "secret": self.config.binance_api_secret.get_secret_value(),
@@ -84,13 +32,105 @@ class BinancePerpStream:
             }
         )
 
+    async def close(self) -> None:
+        self._stopping.set()
+        await self.exchange.close()
+
+    async def stream_symbol(self, symbol: str, timeframe: str) -> None:
+        backoff = 1.0
+        stream_id = f"{symbol}:{timeframe}"
+        while not self._stopping.is_set():
+            heartbeat_task = asyncio.create_task(self._heartbeat(symbol, timeframe))
+            try:
+                await self._ensure_markets_loaded()
+                while not self._stopping.is_set():
+                    if heartbeat_task.done():
+                        heartbeat_task.result()
+                    orderbook_task = asyncio.create_task(
+                        self.exchange.watch_order_book(symbol, limit=20)
+                    )
+                    ticker_task = asyncio.create_task(
+                        self.exchange.watch_ticker(symbol)
+                    )
+                    try:
+                        orderbook, ticker = await asyncio.wait_for(
+                            asyncio.gather(orderbook_task, ticker_task),
+                            timeout=self.config.websocket_timeout_seconds,
+                        )
+                    except TimeoutError as exc:
+                        for task in (orderbook_task, ticker_task):
+                            task.cancel()
+                        await asyncio.gather(
+                            orderbook_task, ticker_task, return_exceptions=True
+                        )
+                        raise TimeoutError(
+                            f"WebSocket stalled for {stream_id}"
+                        ) from exc
+                    ohlcv = await self.exchange.fetch_ohlcv(
+                        symbol, timeframe=timeframe, limit=250
+                    )
+                    await self.on_snapshot(
+                        MarketSnapshot(symbol, timeframe, ohlcv, ticker, orderbook)
+                    )
+                    backoff = 1.0
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                raise
+            except Exception as exc:
+                self.logger.warning(
+                    "websocket_reconnect",
+                    extra={
+                        "symbol": symbol,
+                        "trace_id": "stream",
+                        "strategy": timeframe,
+                    },
+                    exc_info=exc,
+                )
+                await self._recreate_exchange()
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2.0, self.config.max_reconnect_backoff_seconds)
+            finally:
+                heartbeat_task.cancel()
+                await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+    async def _ensure_markets_loaded(self) -> None:
+        if self._markets_loaded:
+            return
+        async with self._reconnect_lock:
+            if not self._markets_loaded:
+                await self.exchange.load_markets()
+                self._markets_loaded = True
+
+    async def _heartbeat(self, symbol: str, timeframe: str) -> None:
+        while not self._stopping.is_set():
+            await asyncio.sleep(self.config.heartbeat_interval_seconds)
+            await asyncio.wait_for(self.exchange.fetch_time(), timeout=10)
+            self.logger.info(
+                "websocket_heartbeat_ok",
+                extra={
+                    "symbol": symbol,
+                    "trace_id": "heartbeat",
+                    "strategy": timeframe,
+                },
+            )
+
+    async def _recreate_exchange(self) -> None:
+        async with self._reconnect_lock:
+            old_exchange = self.exchange
+            self.exchange = self._build_exchange()
+            self._markets_loaded = False
+            await old_exchange.close()
+
     async def fetch_equity_usdt(self) -> float:
         balance = await self.exchange.fetch_balance({"type": "swap"})
         return float(balance["USDT"]["total"])
 
     async def execute(self, intent: PositionIntent) -> dict[str, Any]:
         if self.config.dry_run:
-            return {"id": f"dry-{intent.signal.trace_id}", "average": intent.signal.metadata.get("price"), "status": "closed"}
+            return {
+                "id": f"dry-{intent.signal.trace_id}",
+                "average": intent.signal.metadata.get("price"),
+                "status": "closed",
+            }
         return await self.exchange.create_order(
             intent.signal.symbol,
             "market",

--- a/apps/backend/src/binance_perp_bot/indicators.py
+++ b/apps/backend/src/binance_perp_bot/indicators.py
@@ -45,7 +45,9 @@ def atr(ohlcv: list[list[float]], period: int = 14) -> float:
     low = lows(ohlcv)
     close = closes(ohlcv)
     previous_close = np.roll(close, 1)
-    true_range = np.maximum(high - low, np.maximum(abs(high - previous_close), abs(low - previous_close)))[1:]
+    true_range = np.maximum(
+        high - low, np.maximum(abs(high - previous_close), abs(low - previous_close))
+    )[1:]
     return float(true_range[-period:].mean())
 
 
@@ -59,9 +61,20 @@ def adx(ohlcv: list[list[float]], period: int = 14) -> float:
     minus_dm = np.maximum(low[:-1] - low[1:], 0.0)
     plus_dm = np.where(plus_dm > minus_dm, plus_dm, 0.0)
     minus_dm = np.where(minus_dm > plus_dm, minus_dm, 0.0)
-    tr = np.maximum(high[1:] - low[1:], np.maximum(abs(high[1:] - close[:-1]), abs(low[1:] - close[:-1])))
+    tr = np.maximum(
+        high[1:] - low[1:],
+        np.maximum(abs(high[1:] - close[:-1]), abs(low[1:] - close[:-1])),
+    )
     atr_series = np.convolve(tr, np.ones(period) / period, mode="valid")
-    plus_di = 100 * np.convolve(plus_dm, np.ones(period) / period, mode="valid") / np.maximum(atr_series, 1e-9)
-    minus_di = 100 * np.convolve(minus_dm, np.ones(period) / period, mode="valid") / np.maximum(atr_series, 1e-9)
+    plus_di = (
+        100
+        * np.convolve(plus_dm, np.ones(period) / period, mode="valid")
+        / np.maximum(atr_series, 1e-9)
+    )
+    minus_di = (
+        100
+        * np.convolve(minus_dm, np.ones(period) / period, mode="valid")
+        / np.maximum(atr_series, 1e-9)
+    )
     dx = 100 * abs(plus_di - minus_di) / np.maximum(plus_di + minus_di, 1e-9)
     return float(dx[-period:].mean())

--- a/apps/backend/src/binance_perp_bot/main.py
+++ b/apps/backend/src/binance_perp_bot/main.py
@@ -42,7 +42,11 @@ async def run() -> None:
         journal=journal,
     )
     dispatcher.handler = engine.on_snapshot
-    tasks = [asyncio.create_task(stream.stream_symbol(symbol, timeframe)) for symbol in config.symbols for timeframe in ("1m", "5m", "4h", "1d", "1w")]
+    tasks = [
+        asyncio.create_task(stream.stream_symbol(symbol, timeframe))
+        for symbol in config.symbols
+        for timeframe in ("1m", "5m", "4h", "1d", "1w")
+    ]
     try:
         await asyncio.gather(*tasks)
     finally:

--- a/apps/backend/src/binance_perp_bot/ml/gate.py
+++ b/apps/backend/src/binance_perp_bot/ml/gate.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 import xgboost as xgb
-
 from binance_perp_bot.indicators import adx, atr, closes, ema, rsi
 from binance_perp_bot.models import MarketSnapshot, TradeSignal
 

--- a/apps/backend/src/binance_perp_bot/risk/position_manager.py
+++ b/apps/backend/src/binance_perp_bot/risk/position_manager.py
@@ -5,8 +5,14 @@ from collections import defaultdict
 from typing import Protocol
 
 import numpy as np
-
-from binance_perp_bot.models import OpenPosition, PositionIntent, Side, SignalAction, StrategyKind, TradeSignal
+from binance_perp_bot.models import (
+    OpenPosition,
+    PositionIntent,
+    Side,
+    SignalAction,
+    StrategyKind,
+    TradeSignal,
+)
 
 
 class AllocationConfigLike(Protocol):
@@ -16,7 +22,9 @@ class AllocationConfigLike(Protocol):
 
 
 class PositionManager:
-    def __init__(self, allocation: AllocationConfigLike, max_correlation: float) -> None:
+    def __init__(
+        self, allocation: AllocationConfigLike, max_correlation: float
+    ) -> None:
         self._allocation = allocation
         self._max_correlation = max_correlation
         self._equity_usdt = 0.0
@@ -33,16 +41,28 @@ class PositionManager:
         async with self._lock:
             self._return_history[symbol] = returns
 
-    async def reserve(self, signal: TradeSignal, price: float, leverage: int) -> PositionIntent | None:
+    async def reserve(
+        self, signal: TradeSignal, price: float, leverage: int
+    ) -> PositionIntent | None:
         if signal.action not in {SignalAction.ENTER_LONG, SignalAction.ENTER_SHORT}:
             return None
         async with self._lock:
             if self._portfolio_correlation(signal.symbol) > self._max_correlation:
                 return None
             heatmap = self._heatmap_locked()
-            allocation_cap = self._equity_usdt * self._target_allocation(signal.strategy) * heatmap[signal.strategy]
-            used = sum(p.notional_usdt for p in self._positions.values() if p.strategy == signal.strategy)
-            available = min(self._equity_usdt - self._reserved_usdt, allocation_cap - used)
+            allocation_cap = (
+                self._equity_usdt
+                * self._target_allocation(signal.strategy)
+                * heatmap[signal.strategy]
+            )
+            used = sum(
+                p.notional_usdt
+                for p in self._positions.values()
+                if p.strategy == signal.strategy
+            )
+            available = min(
+                self._equity_usdt - self._reserved_usdt, allocation_cap - used
+            )
             notional = min(signal.size_usdt, max(0.0, available))
             if notional <= 0:
                 return None
@@ -53,7 +73,10 @@ class PositionManager:
 
     async def commit_open(self, intent: PositionIntent, fill_price: float) -> None:
         async with self._lock:
-            key = f"{intent.signal.strategy}:{intent.signal.symbol}:{intent.signal.trace_id}"
+            key = (
+                f"{intent.signal.strategy}:{intent.signal.symbol}:"
+                f"{intent.signal.trace_id}"
+            )
             self._positions[key] = OpenPosition(
                 symbol=intent.signal.symbol,
                 strategy=intent.signal.strategy,
@@ -82,7 +105,12 @@ class PositionManager:
             exposure[position.strategy] += position.notional_usdt
         total = sum(exposure.values()) or 1.0
         return {
-            kind: max(0.50, min(1.25, 1.0 - (exposure[kind] / total - self._target_allocation(kind))))
+            kind: max(
+                0.50,
+                min(
+                    1.25, 1.0 - (exposure[kind] / total - self._target_allocation(kind))
+                ),
+            )
             for kind in StrategyKind
         }
 

--- a/apps/backend/src/binance_perp_bot/strategies/__init__.py
+++ b/apps/backend/src/binance_perp_bot/strategies/__init__.py
@@ -1,5 +1,15 @@
 from binance_perp_bot.strategies.base import BaseStrategy
-from binance_perp_bot.strategies.concrete import PositionStrategy, ScalpStrategy, SwingStrategy
+from binance_perp_bot.strategies.concrete import (
+    PositionStrategy,
+    ScalpStrategy,
+    SwingStrategy,
+)
 from binance_perp_bot.strategies.factory import StrategyFactory
 
-__all__ = ["BaseStrategy", "PositionStrategy", "ScalpStrategy", "StrategyFactory", "SwingStrategy"]
+__all__ = [
+    "BaseStrategy",
+    "PositionStrategy",
+    "ScalpStrategy",
+    "StrategyFactory",
+    "SwingStrategy",
+]

--- a/apps/backend/src/binance_perp_bot/strategies/base.py
+++ b/apps/backend/src/binance_perp_bot/strategies/base.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from binance_perp_bot.models import MarketSnapshot, RegimeMode, StrategyKind, TradeSignal
+from binance_perp_bot.models import (
+    MarketSnapshot,
+    RegimeMode,
+    StrategyKind,
+    TradeSignal,
+)
 
 
 class BaseStrategy(ABC):
@@ -10,11 +15,15 @@ class BaseStrategy(ABC):
     timeframes: tuple[str, ...]
 
     @abstractmethod
-    def check_signal(self, snapshot: MarketSnapshot, regime: RegimeMode) -> TradeSignal | None:
+    def check_signal(
+        self, snapshot: MarketSnapshot, regime: RegimeMode
+    ) -> TradeSignal | None:
         """Return a trade signal only when technical confluence is present."""
 
     @abstractmethod
-    def calculate_size(self, snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float) -> float:
+    def calculate_size(
+        self, snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float
+    ) -> float:
         """Return ATR-adjusted notional size in USDT."""
 
     @abstractmethod

--- a/apps/backend/src/binance_perp_bot/strategies/concrete.py
+++ b/apps/backend/src/binance_perp_bot/strategies/concrete.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 from binance_perp_bot.indicators import atr, closes, ema, rsi
-from binance_perp_bot.models import MarketSnapshot, RegimeMode, SignalAction, StrategyKind, TradeSignal
+from binance_perp_bot.models import (
+    MarketSnapshot,
+    RegimeMode,
+    SignalAction,
+    StrategyKind,
+    TradeSignal,
+)
 from binance_perp_bot.strategies.base import BaseStrategy
 
 
-def atr_scaled_notional(snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float) -> float:
+def atr_scaled_notional(
+    snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float
+) -> float:
     close = closes(snapshot.ohlcv)[-1]
     volatility = atr(snapshot.ohlcv) / max(close, 1e-9)
     multiplier = max(0.35, min(1.50, 0.01 / max(volatility, 0.001)))
@@ -16,63 +24,99 @@ class ScalpStrategy(BaseStrategy):
     kind = StrategyKind.SCALP
     timeframes = ("1m", "5m")
 
-    def check_signal(self, snapshot: MarketSnapshot, regime: RegimeMode) -> TradeSignal | None:
+    def check_signal(
+        self, snapshot: MarketSnapshot, regime: RegimeMode
+    ) -> TradeSignal | None:
         price = closes(snapshot.ohlcv)
         fast = ema(price, 8)
         slow = ema(price, 21)
         momentum = rsi(price, 7)
         if fast > slow and 52 <= momentum <= 72:
-            return TradeSignal(snapshot.symbol, self.kind, SignalAction.ENTER_LONG, 0.68, 0.0, regime)
+            return TradeSignal(
+                snapshot.symbol, self.kind, SignalAction.ENTER_LONG, 0.68, 0.0, regime
+            )
         if fast < slow and 28 <= momentum <= 48:
-            return TradeSignal(snapshot.symbol, self.kind, SignalAction.ENTER_SHORT, 0.68, 0.0, regime)
+            return TradeSignal(
+                snapshot.symbol, self.kind, SignalAction.ENTER_SHORT, 0.68, 0.0, regime
+            )
         return None
 
-    def calculate_size(self, snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float) -> float:
+    def calculate_size(
+        self, snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float
+    ) -> float:
         return atr_scaled_notional(snapshot, equity_usdt, base_notional_usdt)
 
     def get_regime_suitability(self, regime: RegimeMode) -> float:
-        return {RegimeMode.MEAN_REVERSION: 0.80, RegimeMode.TREND: 0.55, RegimeMode.HIGH_VOLATILITY: 0.25}[regime]
+        return {
+            RegimeMode.MEAN_REVERSION: 0.80,
+            RegimeMode.TREND: 0.55,
+            RegimeMode.HIGH_VOLATILITY: 0.25,
+        }[regime]
 
 
 class SwingStrategy(BaseStrategy):
     kind = StrategyKind.SWING
     timeframes = ("4h", "1d")
 
-    def check_signal(self, snapshot: MarketSnapshot, regime: RegimeMode) -> TradeSignal | None:
+    def check_signal(
+        self, snapshot: MarketSnapshot, regime: RegimeMode
+    ) -> TradeSignal | None:
         price = closes(snapshot.ohlcv)
         fast = ema(price, 20)
         slow = ema(price, 50)
         momentum = rsi(price, 14)
         if fast > slow and momentum > 55:
-            return TradeSignal(snapshot.symbol, self.kind, SignalAction.ENTER_LONG, 0.72, 0.0, regime)
+            return TradeSignal(
+                snapshot.symbol, self.kind, SignalAction.ENTER_LONG, 0.72, 0.0, regime
+            )
         if fast < slow and momentum < 45:
-            return TradeSignal(snapshot.symbol, self.kind, SignalAction.ENTER_SHORT, 0.72, 0.0, regime)
+            return TradeSignal(
+                snapshot.symbol, self.kind, SignalAction.ENTER_SHORT, 0.72, 0.0, regime
+            )
         return None
 
-    def calculate_size(self, snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float) -> float:
+    def calculate_size(
+        self, snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float
+    ) -> float:
         return atr_scaled_notional(snapshot, equity_usdt, base_notional_usdt)
 
     def get_regime_suitability(self, regime: RegimeMode) -> float:
-        return {RegimeMode.TREND: 0.90, RegimeMode.MEAN_REVERSION: 0.45, RegimeMode.HIGH_VOLATILITY: 0.35}[regime]
+        return {
+            RegimeMode.TREND: 0.90,
+            RegimeMode.MEAN_REVERSION: 0.45,
+            RegimeMode.HIGH_VOLATILITY: 0.35,
+        }[regime]
 
 
 class PositionStrategy(BaseStrategy):
     kind = StrategyKind.POSITION
     timeframes = ("1d", "1w")
 
-    def check_signal(self, snapshot: MarketSnapshot, regime: RegimeMode) -> TradeSignal | None:
+    def check_signal(
+        self, snapshot: MarketSnapshot, regime: RegimeMode
+    ) -> TradeSignal | None:
         price = closes(snapshot.ohlcv)
         fast = ema(price, 50)
         slow = ema(price, 200)
         momentum = rsi(price, 21)
         if fast > slow and momentum >= 50:
-            return TradeSignal(snapshot.symbol, self.kind, SignalAction.ENTER_LONG, 0.76, 0.0, regime)
+            return TradeSignal(
+                snapshot.symbol, self.kind, SignalAction.ENTER_LONG, 0.76, 0.0, regime
+            )
         if fast < slow and momentum <= 50:
-            return TradeSignal(snapshot.symbol, self.kind, SignalAction.ENTER_SHORT, 0.76, 0.0, regime)
+            return TradeSignal(
+                snapshot.symbol, self.kind, SignalAction.ENTER_SHORT, 0.76, 0.0, regime
+            )
         return None
 
-    def calculate_size(self, snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float) -> float:
+    def calculate_size(
+        self, snapshot: MarketSnapshot, equity_usdt: float, base_notional_usdt: float
+    ) -> float:
         return atr_scaled_notional(snapshot, equity_usdt, base_notional_usdt)
 
     def get_regime_suitability(self, regime: RegimeMode) -> float:
-        return {RegimeMode.TREND: 0.95, RegimeMode.MEAN_REVERSION: 0.30, RegimeMode.HIGH_VOLATILITY: 0.40}[regime]
+        return {
+            RegimeMode.TREND: 0.95,
+            RegimeMode.MEAN_REVERSION: 0.30,
+            RegimeMode.HIGH_VOLATILITY: 0.40,
+        }[regime]

--- a/apps/backend/src/binance_perp_bot/strategies/factory.py
+++ b/apps/backend/src/binance_perp_bot/strategies/factory.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 from binance_perp_bot.models import StrategyKind
 from binance_perp_bot.strategies.base import BaseStrategy
-from binance_perp_bot.strategies.concrete import PositionStrategy, ScalpStrategy, SwingStrategy
+from binance_perp_bot.strategies.concrete import (
+    PositionStrategy,
+    ScalpStrategy,
+    SwingStrategy,
+)
 
 
 class StrategyFactory:
     def __init__(self, strategies: list[BaseStrategy] | None = None) -> None:
-        self._strategies = strategies or [ScalpStrategy(), SwingStrategy(), PositionStrategy()]
+        self._strategies = strategies or [
+            ScalpStrategy(),
+            SwingStrategy(),
+            PositionStrategy(),
+        ]
 
     def all(self) -> list[BaseStrategy]:
         return list(self._strategies)

--- a/apps/backend/src/binance_perp_bot/utils/logging.py
+++ b/apps/backend/src/binance_perp_bot/utils/logging.py
@@ -9,7 +9,8 @@ from pythonjsonlogger import jsonlogger
 def configure_json_logging(level: int = logging.INFO) -> None:
     handler = logging.StreamHandler(sys.stdout)
     formatter = jsonlogger.JsonFormatter(
-        "%(asctime)s %(levelname)s %(name)s %(message)s %(trace_id)s %(symbol)s %(strategy)s"
+        "%(asctime)s %(levelname)s %(name)s %(message)s "
+        "%(trace_id)s %(symbol)s %(strategy)s"
     )
     handler.setFormatter(formatter)
     root = logging.getLogger()

--- a/tests/test_binance_perp_bot.py
+++ b/tests/test_binance_perp_bot.py
@@ -3,10 +3,20 @@ from __future__ import annotations
 import asyncio
 
 import numpy as np
-
-from binance_perp_bot.models import MarketSnapshot, RegimeMode, SignalAction, StrategyKind, TradeSignal
+from binance_perp_bot.models import (
+    MarketSnapshot,
+    RegimeMode,
+    SignalAction,
+    StrategyKind,
+    TradeSignal,
+)
 from binance_perp_bot.risk.position_manager import PositionManager
-from binance_perp_bot.strategies import BaseStrategy, PositionStrategy, ScalpStrategy, SwingStrategy
+from binance_perp_bot.strategies import (
+    BaseStrategy,
+    PositionStrategy,
+    ScalpStrategy,
+    SwingStrategy,
+)
 
 
 class Allocation:
@@ -16,11 +26,20 @@ class Allocation:
 
 
 def candles(count: int = 250) -> list[list[float]]:
-    return [[i * 60_000, 100 + i * 0.1, 101 + i * 0.1, 99 + i * 0.1, 100 + i * 0.1, 10] for i in range(count)]
+    return [
+        [i * 60_000, 100 + i * 0.1, 101 + i * 0.1, 99 + i * 0.1, 100 + i * 0.1, 10]
+        for i in range(count)
+    ]
 
 
 def snapshot(symbol: str = "BTC/USDT:USDT") -> MarketSnapshot:
-    return MarketSnapshot(symbol=symbol, timeframe="1m", ohlcv=candles(), ticker={"last": 125.0}, orderbook={})
+    return MarketSnapshot(
+        symbol=symbol,
+        timeframe="1m",
+        ohlcv=candles(),
+        ticker={"last": 125.0},
+        orderbook={},
+    )
 
 
 def test_concrete_strategies_implement_base_contract() -> None:
@@ -37,11 +56,25 @@ def test_position_manager_rejects_high_correlation() -> None:
         returns = np.linspace(-0.01, 0.01, 30)
         await manager.set_return_history("BTC/USDT:USDT", returns)
         await manager.set_return_history("ETH/USDT:USDT", returns)
-        signal = TradeSignal("BTC/USDT:USDT", StrategyKind.SCALP, SignalAction.ENTER_LONG, 0.9, 100, RegimeMode.TREND)
+        signal = TradeSignal(
+            "BTC/USDT:USDT",
+            StrategyKind.SCALP,
+            SignalAction.ENTER_LONG,
+            0.9,
+            100,
+            RegimeMode.TREND,
+        )
         first = await manager.reserve(signal, 100, 3)
         assert first is not None
         await manager.commit_open(first, 100)
-        correlated = TradeSignal("ETH/USDT:USDT", StrategyKind.SCALP, SignalAction.ENTER_LONG, 0.9, 100, RegimeMode.TREND)
+        correlated = TradeSignal(
+            "ETH/USDT:USDT",
+            StrategyKind.SCALP,
+            SignalAction.ENTER_LONG,
+            0.9,
+            100,
+            RegimeMode.TREND,
+        )
         assert await manager.reserve(correlated, 100, 3) is None
 
     asyncio.run(scenario())


### PR DESCRIPTION
### Motivation
- Improve runtime resilience of the Binance USDT perpetual streaming and execution pipeline for production-grade operation. 
- Ensure the risk engine has fresh return history to enforce the correlation filter before committing capital. 
- Make configuration and DB migration safer and validate allocation inputs to avoid invalid runtime state. 

### Description
- Hardened the `ccxt.pro` stream in `execution/exchange.py` by centralizing exchange construction, adding market-load caching (`_ensure_markets_loaded`), a reconnect lock, improved heartbeat handling and cleanup, timeout-aware gather logic, and robust exchange recreation. 
- Wired OHLCV-derived returns into the execution flow by adding `_update_return_history` in `execution/engine.py` and calling `PositionManager.set_return_history` to feed the correlation filter. 
- Added allocation validation to `AllocationConfig` in `config.py` with Pydantic `@model_validator` to ensure allocations sum to `1.0` and tightened several `Field` constraints. 
- Made TimescaleDB migration tolerant in `db/timescale.py` by gracefully falling back when TimescaleDB extension creation fails while still creating tables, and formatted SQL insert blocks for readability. 
- Various formatting, import grouping and small API polishing across strategy implementations, indicators, logging format, and tests for consistent style and clearer debug metadata. 

### Testing
- Lint/format: ran `python -m ruff check apps/backend/src/binance_perp_bot tests/test_binance_perp_bot.py` and auto-formatting with `python -m ruff format`, which completed with no outstanding linter failures. (Passed) 
- Unit tests: ran `PYTHONPATH=apps/backend/src pytest -q tests/test_binance_perp_bot.py` and both tests passed (`2 passed`). 
- Bytecode/compile check: ran `python -m compileall -q apps/backend/src/binance_perp_bot`, which succeeded. 
- Sanity: ran `git diff --check` to ensure no whitespace/merge artifacts remain, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2dd92b78832197291234fbc6514a)