### PR TITLE
Add atomic PositionManager and RiskEngine for portfolio risk gating

### DIFF
--- a/apps/backend/src/binance_perp_bot/models.py
+++ b/apps/backend/src/binance_perp_bot/models.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Side(str, Enum):
@@ -29,6 +31,40 @@ class StrategyKind(str, Enum):
     SCALP = "scalp"
     SWING = "swing"
     POSITION = "position"
+
+
+class Position(BaseModel):
+    """Immutable audit-friendly portfolio position record.
+
+    PositionManager is the only component that should create or remove these records.
+    Keeping the model frozen makes accidental out-of-band mutation impossible and
+    preserves the trace_id/open_time data needed to reconstruct an order lifecycle.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    strategy_id: str
+    symbol: str
+    side: Literal["LONG", "SHORT"]
+    size: float
+    entry_price: float
+    leverage: int
+    margin_used: float
+    open_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    regime_at_open: str
+    trace_id: str
+
+    @property
+    def notional_value(self) -> float:
+        return self.size * self.entry_price
+
+    @property
+    def strategy_kind(self) -> StrategyKind | None:
+        try:
+            return StrategyKind(self.strategy_id)
+        except ValueError:
+            return None
 
 
 @dataclass(frozen=True)

--- a/apps/backend/src/binance_perp_bot/risk/__init__.py
+++ b/apps/backend/src/binance_perp_bot/risk/__init__.py
@@ -1,0 +1,4 @@
+from binance_perp_bot.risk.position_manager import PositionManager
+from binance_perp_bot.risk.risk_engine import RiskEngine
+
+__all__ = ["PositionManager", "RiskEngine"]

--- a/apps/backend/src/binance_perp_bot/risk/position_manager.py
+++ b/apps/backend/src/binance_perp_bot/risk/position_manager.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections import defaultdict
 from typing import Protocol
 
 import numpy as np
 from binance_perp_bot.models import (
-    OpenPosition,
+    Position,
     PositionIntent,
+    RegimeMode,
     Side,
     SignalAction,
     StrategyKind,
     TradeSignal,
 )
+from binance_perp_bot.risk.risk_engine import RiskEngine
 
 
 class AllocationConfigLike(Protocol):
@@ -22,16 +25,37 @@ class AllocationConfigLike(Protocol):
 
 
 class PositionManager:
+    """Atomic single source of truth for shared-capital open positions."""
+
     def __init__(
-        self, allocation: AllocationConfigLike, max_correlation: float
+        self,
+        allocation: AllocationConfigLike,
+        max_correlation: float,
+        max_positions: int = 30,
+        risk_engine: RiskEngine | None = None,
     ) -> None:
         self._allocation = allocation
         self._max_correlation = max_correlation
+        self._max_positions = max_positions
         self._equity_usdt = 0.0
         self._reserved_usdt = 0.0
-        self._positions: dict[str, OpenPosition] = {}
+        self._positions: dict[str, Position] = {}
         self._return_history: dict[str, np.ndarray] = {}
         self._lock = asyncio.Lock()
+        self.risk_engine = risk_engine or RiskEngine(max_correlation)
+        self.logger = logging.getLogger("PositionManager")
+
+    @property
+    def total_equity(self) -> float:
+        return self._equity_usdt
+
+    @property
+    def used_margin(self) -> float:
+        return sum(position.margin_used for position in self._positions.values())
+
+    @property
+    def current_exposure(self) -> float:
+        return sum(position.notional_value for position in self._positions.values())
 
     async def update_equity(self, equity_usdt: float) -> None:
         async with self._lock:
@@ -40,6 +64,64 @@ class PositionManager:
     async def set_return_history(self, symbol: str, returns: np.ndarray) -> None:
         async with self._lock:
             self._return_history[symbol] = returns
+            prices = np.cumprod(1.0 + returns)
+            self.risk_engine.set_price_history(symbol, prices)
+
+    async def positions(self) -> list[Position]:
+        async with self._lock:
+            return list(self._positions.values())
+
+    async def can_open_new_position(self) -> bool:
+        async with self._lock:
+            return self._can_open_new_position_locked()
+
+    async def open_position(self, position: Position) -> bool:
+        async with self._lock:
+            if not self._can_open_new_position_locked():
+                self.logger.warning(
+                    "max_positions_reached",
+                    extra={
+                        "trace_id": position.trace_id,
+                        "symbol": position.symbol,
+                        "max_positions": self._max_positions,
+                    },
+                )
+                return False
+            if any(
+                existing.symbol == position.symbol
+                for existing in self._positions.values()
+            ):
+                self.logger.warning(
+                    "duplicate_symbol_position_rejected",
+                    extra={"trace_id": position.trace_id, "symbol": position.symbol},
+                )
+                return False
+            self._positions[position.id] = position
+            self.logger.info(
+                "position_registered",
+                extra={
+                    "trace_id": position.trace_id,
+                    "symbol": position.symbol,
+                    "side": position.side,
+                },
+            )
+            return True
+
+    async def close_position(
+        self, position_id: str, exit_price: float, trace_id: str
+    ) -> Position | None:
+        async with self._lock:
+            position = self._positions.pop(position_id, None)
+            if position is not None:
+                self.logger.info(
+                    "position_closed",
+                    extra={
+                        "trace_id": trace_id,
+                        "symbol": position.symbol,
+                        "exit_price": exit_price,
+                    },
+                )
+            return position
 
     async def reserve(
         self, signal: TradeSignal, price: float, leverage: int
@@ -47,6 +129,34 @@ class PositionManager:
         if signal.action not in {SignalAction.ENTER_LONG, SignalAction.ENTER_SHORT}:
             return None
         async with self._lock:
+            side = "LONG" if signal.action == SignalAction.ENTER_LONG else "SHORT"
+            if not self._can_open_new_position_locked():
+                self.logger.warning(
+                    "max_positions_reached",
+                    extra={
+                        "trace_id": signal.trace_id,
+                        "symbol": signal.symbol,
+                        "max_positions": self._max_positions,
+                    },
+                )
+                return None
+            if any(
+                position.symbol == signal.symbol
+                for position in self._positions.values()
+            ):
+                self.logger.warning(
+                    "duplicate_symbol_position_rejected",
+                    extra={"trace_id": signal.trace_id, "symbol": signal.symbol},
+                )
+                return None
+            if not self.risk_engine.resolve_conflict(
+                side, self._positions.values(), signal.symbol
+            ):
+                return None
+            if not self.risk_engine.check_correlation(
+                signal.symbol, self._positions.values()
+            ):
+                return None
             if self._portfolio_correlation(signal.symbol) > self._max_correlation:
                 return None
             heatmap = self._heatmap_locked()
@@ -56,41 +166,67 @@ class PositionManager:
                 * heatmap[signal.strategy]
             )
             used = sum(
-                p.notional_usdt
+                p.margin_used
                 for p in self._positions.values()
-                if p.strategy == signal.strategy
+                if p.strategy_kind == signal.strategy
             )
             available = min(
-                self._equity_usdt - self._reserved_usdt, allocation_cap - used
+                self._equity_usdt - self._reserved_usdt - self.used_margin,
+                allocation_cap - used,
             )
-            notional = min(signal.size_usdt, max(0.0, available))
-            if notional <= 0:
+            margin = min(signal.size_usdt, max(0.0, available))
+            if margin <= 0:
                 return None
-            self._reserved_usdt += notional
-            side = Side.BUY if signal.action == SignalAction.ENTER_LONG else Side.SELL
-            amount = notional * leverage / price
-            return PositionIntent(signal, side, amount, notional, leverage)
+            self._reserved_usdt += margin
+            order_side = (
+                Side.BUY if signal.action == SignalAction.ENTER_LONG else Side.SELL
+            )
+            amount = margin * leverage / price
+            return PositionIntent(signal, order_side, amount, margin, leverage)
 
     async def commit_open(self, intent: PositionIntent, fill_price: float) -> None:
+        side = "LONG" if intent.side == Side.BUY else "SHORT"
+        regime = intent.signal.regime
+        position = Position(
+            strategy_id=intent.signal.strategy.value,
+            symbol=intent.signal.symbol,
+            side=side,
+            size=intent.amount,
+            entry_price=fill_price,
+            leverage=intent.leverage,
+            margin_used=intent.notional_usdt,
+            regime_at_open=(
+                regime.value if isinstance(regime, RegimeMode) else str(regime)
+            ),
+            trace_id=intent.signal.trace_id,
+        )
         async with self._lock:
-            key = (
-                f"{intent.signal.strategy}:{intent.signal.symbol}:"
-                f"{intent.signal.trace_id}"
-            )
-            self._positions[key] = OpenPosition(
-                symbol=intent.signal.symbol,
-                strategy=intent.signal.strategy,
-                notional_usdt=intent.notional_usdt,
-                side=intent.side,
-                entry_price=fill_price,
-                amount=intent.amount,
-                trace_id=intent.signal.trace_id,
-            )
             self._reserved_usdt = max(0.0, self._reserved_usdt - intent.notional_usdt)
+        opened = await self.open_position(position)
+        if not opened:
+            self.logger.warning(
+                "position_commit_rejected_after_fill",
+                extra={
+                    "trace_id": intent.signal.trace_id,
+                    "symbol": intent.signal.symbol,
+                },
+            )
 
     async def release(self, intent: PositionIntent) -> None:
         async with self._lock:
             self._reserved_usdt = max(0.0, self._reserved_usdt - intent.notional_usdt)
+
+    def get_portfolio_heatmap(self) -> dict[str, float]:
+        total = (
+            sum(position.margin_used for position in self._positions.values()) or 1.0
+        )
+        return {
+            position.symbol: position.margin_used / total
+            for position in self._positions.values()
+        }
+
+    def _can_open_new_position_locked(self) -> bool:
+        return len(self._positions) < self._max_positions
 
     def _target_allocation(self, strategy: StrategyKind) -> float:
         return {
@@ -102,7 +238,9 @@ class PositionManager:
     def _heatmap_locked(self) -> dict[StrategyKind, float]:
         exposure = defaultdict(float)
         for position in self._positions.values():
-            exposure[position.strategy] += position.notional_usdt
+            kind = position.strategy_kind
+            if kind is not None:
+                exposure[kind] += position.margin_used
         total = sum(exposure.values()) or 1.0
         return {
             kind: max(

--- a/apps/backend/src/binance_perp_bot/risk/risk_engine.py
+++ b/apps/backend/src/binance_perp_bot/risk/risk_engine.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+from collections import deque
+from collections.abc import Iterable, Sequence
+from typing import Deque
+
+import numpy as np
+from binance_perp_bot.models import Position
+
+
+class RiskEngine:
+    """Pre-trade portfolio gate for correlation and strategy conflict checks."""
+
+    def __init__(
+        self, correlation_threshold: float = 0.65, history_window: int = 120
+    ) -> None:
+        self.threshold = correlation_threshold
+        self.history_window = history_window
+        self.price_history: dict[str, Deque[float]] = {}
+        self.logger = logging.getLogger("RiskEngine")
+
+    def set_price_history(self, symbol: str, prices: Sequence[float]) -> None:
+        history: Deque[float] = deque(maxlen=self.history_window)
+        history.extend(float(price) for price in prices[-self.history_window :])
+        self.price_history[symbol] = history
+
+    def update_price(self, symbol: str, price: float) -> None:
+        self.price_history.setdefault(symbol, deque(maxlen=self.history_window)).append(
+            float(price)
+        )
+
+    def check_correlation(
+        self, new_symbol: str, current_positions: Iterable[Position]
+    ) -> bool:
+        incoming = self._returns(new_symbol)
+        if incoming is None:
+            return True
+
+        for position in current_positions:
+            existing = self._returns(position.symbol)
+            if existing is None:
+                continue
+            window = min(incoming.size, existing.size)
+            if window < 20:
+                continue
+            corr = np.corrcoef(incoming[-window:], existing[-window:])[0, 1]
+            if np.isfinite(corr) and abs(float(corr)) > self.threshold:
+                self.logger.warning(
+                    "correlation_too_high",
+                    extra={
+                        "symbol": new_symbol,
+                        "existing_symbol": position.symbol,
+                        "correlation": float(corr),
+                        "trace_id": position.trace_id,
+                    },
+                )
+                return False
+        return True
+
+    def resolve_conflict(
+        self, new_signal: str, current_positions: Iterable[Position], symbol: str
+    ) -> bool:
+        normalized_signal = new_signal.upper()
+        for position in current_positions:
+            if position.symbol != symbol:
+                continue
+            is_position_strategy = "position" in position.strategy_id.lower()
+            is_opposite_side = position.side != normalized_signal
+            if is_position_strategy and is_opposite_side:
+                self.logger.info(
+                    "position_conflict_detected",
+                    extra={
+                        "symbol": symbol,
+                        "existing_side": position.side,
+                        "incoming_side": normalized_signal,
+                        "trace_id": position.trace_id,
+                    },
+                )
+                return False
+        return True
+
+    def _returns(self, symbol: str) -> np.ndarray | None:
+        history = self.price_history.get(symbol)
+        if history is None or len(history) < 21:
+            return None
+        prices = np.asarray(history, dtype=float)
+        return np.diff(prices) / np.maximum(prices[:-1], 1e-9)

--- a/tests/test_binance_perp_bot.py
+++ b/tests/test_binance_perp_bot.py
@@ -78,3 +78,33 @@ def test_position_manager_rejects_high_correlation() -> None:
         assert await manager.reserve(correlated, 100, 3) is None
 
     asyncio.run(scenario())
+
+
+def test_position_manager_rejects_duplicate_symbol_atomically() -> None:
+    async def scenario() -> None:
+        manager = PositionManager(Allocation(), max_correlation=0.65, max_positions=1)
+        await manager.update_equity(1_000)
+        signal = TradeSignal(
+            "BTC/USDT:USDT",
+            StrategyKind.SCALP,
+            SignalAction.ENTER_LONG,
+            0.9,
+            100,
+            RegimeMode.TREND,
+        )
+        first = await manager.reserve(signal, 100, 3)
+        assert first is not None
+        await manager.commit_open(first, 100)
+
+        duplicate = TradeSignal(
+            "BTC/USDT:USDT",
+            StrategyKind.SWING,
+            SignalAction.ENTER_LONG,
+            0.9,
+            100,
+            RegimeMode.TREND,
+        )
+        assert await manager.reserve(duplicate, 100, 3) is None
+        assert len(await manager.positions()) == 1
+
+    asyncio.run(scenario())


### PR DESCRIPTION
### Motivation
- Prevent race conditions and accidental over-leverage in a shared-capital multi-strategy environment by centralising position lifecycle and pre-trade risk checks. 
- Provide immutable, auditable position records so lifecycle events can be traced reliably across components.

### Description
- Add a frozen `Position` model (`pydantic`) with `trace_id`, `open_time`, `regime_at_open`, and helper properties for notional and strategy kind (`apps/backend/src/binance_perp_bot/models.py`).
- Introduce `RiskEngine` that maintains bounded `price_history` (deque), computes returns, checks correlation, and resolves long-term vs scalping conflicts (`apps/backend/src/binance_perp_bot/risk/risk_engine.py`).
- Rework `PositionManager` into an atomic single source-of-truth using `asyncio.Lock`, track `total_equity`/`reserved_usdt`/`used_margin`, enforce `max_positions` and duplicate-symbol rejection, run risk gates before reserving margin, and register immutable `Position` on commit (`apps/backend/src/binance_perp_bot/risk/position_manager.py`).
- Export `PositionManager` and `RiskEngine` from the `risk` package and add a regression test to ensure duplicate-symbol/max-position behavior (`apps/backend/src/binance_perp_bot/risk/__init__.py`, `tests/test_binance_perp_bot.py`).

### Testing
- Ran unit tests with `PYTHONPATH=apps/backend/src pytest -q` and all tests passed (`10 passed`).
- Ran linter/formatter checks with `ruff check` / `ruff format`, fixed formatting issues, and verified no remaining critical linter failures (only a repo config deprecation warning from `ruff`).
- Executed the focused test file `pytest -q tests/test_binance_perp_bot.py` which also passed (`3 passed` during iteration to add the regression test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb317758a48321a34978a9e8680bd6)