### PR TITLE
Upgrade Omega risk controls

### DIFF
--- a/apps/backend/src/binance_perp_bot/config.py
+++ b/apps/backend/src/binance_perp_bot/config.py
@@ -16,6 +16,8 @@ class BotConfig(BaseSettings):
     )
     fixed_notional_usdt: float = Field(default=100.0, gt=0)
     max_correlation: float = Field(default=0.65, gt=0, lt=1)
+    max_positions: int = Field(default=30, ge=1, le=200)
+    max_margin_ratio: float = Field(default=0.80, gt=0, le=1)
     websocket_timeout_seconds: float = Field(default=30.0, gt=0)
     heartbeat_interval_seconds: float = Field(default=15.0, gt=0)
     max_reconnect_backoff_seconds: float = Field(default=60.0, gt=1)

--- a/apps/backend/src/binance_perp_bot/main.py
+++ b/apps/backend/src/binance_perp_bot/main.py
@@ -36,22 +36,23 @@ async def run() -> None:
         config=config,
         stream=stream,
         factory=StrategyFactory(),
-        position_manager=PositionManager(AllocationConfig(), config.max_correlation),
+        position_manager=PositionManager(
+            AllocationConfig(),
+            config.max_correlation,
+            max_positions=config.max_positions,
+            max_margin_ratio=config.max_margin_ratio,
+        ),
         regime_detector=ADXRegimeDetector(),
         trade_gate=XGBoostTradeGate(config.ml_model_path),
         journal=journal,
     )
     dispatcher.handler = engine.on_snapshot
-    tasks = [
-        asyncio.create_task(stream.stream_symbol(symbol, timeframe))
-        for symbol in config.symbols
-        for timeframe in ("1m", "5m", "4h", "1d", "1w")
-    ]
     try:
-        await asyncio.gather(*tasks)
+        async with asyncio.TaskGroup() as task_group:
+            for symbol in config.symbols:
+                for timeframe in ("1m", "5m", "4h", "1d", "1w"):
+                    task_group.create_task(stream.stream_symbol(symbol, timeframe))
     finally:
-        for task in tasks:
-            task.cancel()
         await stream.close()
 
 

--- a/apps/backend/src/binance_perp_bot/risk/position_manager.py
+++ b/apps/backend/src/binance_perp_bot/risk/position_manager.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
 from typing import Protocol
 
 import numpy as np
@@ -21,25 +24,65 @@ class AllocationConfigLike(Protocol):
     position: float
 
 
+class RiskRejectionReason(str, Enum):
+    MAX_POSITIONS = "max_positions"
+    MARGIN_RATIO = "margin_ratio"
+    CORRELATION = "correlation"
+    CONFLICT = "conflict"
+    ALLOCATION = "allocation"
+
+
+@dataclass(frozen=True)
+class PortfolioSnapshot:
+    equity_usdt: float
+    reserved_usdt: float
+    used_margin_usdt: float
+    open_positions: tuple[OpenPosition, ...]
+    strategy_heatmap: dict[StrategyKind, float]
+    margin_ratio: float
+
+
 class PositionManager:
+    """Single source of truth for capital, position state, and risk admission.
+
+    The manager intentionally keeps reservation, correlation, conflict, and commit
+    checks under one asyncio lock. That makes signal-to-order admission atomic
+    across concurrent timeframe workers and prevents double-spending shared USDT
+    equity while WebSocket tasks are yielding control.
+    """
+
     def __init__(
-        self, allocation: AllocationConfigLike, max_correlation: float
+        self,
+        allocation: AllocationConfigLike,
+        max_correlation: float,
+        *,
+        max_positions: int = 30,
+        max_margin_ratio: float = 0.80,
     ) -> None:
         self._allocation = allocation
         self._max_correlation = max_correlation
+        self._max_positions = max_positions
+        self._max_margin_ratio = max_margin_ratio
         self._equity_usdt = 0.0
         self._reserved_usdt = 0.0
         self._positions: dict[str, OpenPosition] = {}
         self._return_history: dict[str, np.ndarray] = {}
         self._lock = asyncio.Lock()
+        self._last_rejection: RiskRejectionReason | None = None
+        self.logger = logging.getLogger(__name__)
+
+    @property
+    def last_rejection(self) -> RiskRejectionReason | None:
+        return self._last_rejection
 
     async def update_equity(self, equity_usdt: float) -> None:
         async with self._lock:
-            self._equity_usdt = equity_usdt
+            self._equity_usdt = max(0.0, equity_usdt)
 
     async def set_return_history(self, symbol: str, returns: np.ndarray) -> None:
+        bounded = np.asarray(returns, dtype=float)[-500:]
         async with self._lock:
-            self._return_history[symbol] = returns
+            self._return_history[symbol] = bounded[np.isfinite(bounded)]
 
     async def reserve(
         self, signal: TradeSignal, price: float, leverage: int
@@ -47,8 +90,16 @@ class PositionManager:
         if signal.action not in {SignalAction.ENTER_LONG, SignalAction.ENTER_SHORT}:
             return None
         async with self._lock:
-            if self._portfolio_correlation(signal.symbol) > self._max_correlation:
-                return None
+            self._last_rejection = None
+            if len(self._positions) >= self._max_positions:
+                return self._reject_locked(signal, RiskRejectionReason.MAX_POSITIONS)
+            if self._has_strategy_conflict_locked(signal):
+                return self._reject_locked(signal, RiskRejectionReason.CONFLICT)
+            correlation = self._portfolio_correlation_locked(signal.symbol)
+            if correlation > self._max_correlation:
+                signal.metadata["portfolio_correlation"] = correlation
+                return self._reject_locked(signal, RiskRejectionReason.CORRELATION)
+
             heatmap = self._heatmap_locked()
             allocation_cap = (
                 self._equity_usdt
@@ -60,15 +111,31 @@ class PositionManager:
                 for p in self._positions.values()
                 if p.strategy == signal.strategy
             )
+            remaining_equity = self._equity_usdt - self._reserved_usdt
+            remaining_margin_capacity = max(
+                0.0, self._equity_usdt * self._max_margin_ratio - self.used_margin_usdt
+            )
             available = min(
-                self._equity_usdt - self._reserved_usdt, allocation_cap - used
+                remaining_equity, allocation_cap - used, remaining_margin_capacity
             )
             notional = min(signal.size_usdt, max(0.0, available))
             if notional <= 0:
-                return None
+                reason = (
+                    RiskRejectionReason.MARGIN_RATIO
+                    if remaining_margin_capacity <= 0
+                    else RiskRejectionReason.ALLOCATION
+                )
+                return self._reject_locked(signal, reason)
             self._reserved_usdt += notional
             side = Side.BUY if signal.action == SignalAction.ENTER_LONG else Side.SELL
             amount = notional * leverage / price
+            signal.metadata.update(
+                {
+                    "reserved_notional_usdt": notional,
+                    "strategy_heatmap": heatmap[signal.strategy],
+                    "margin_ratio": self._margin_ratio_locked(),
+                }
+            )
             return PositionIntent(signal, side, amount, notional, leverage)
 
     async def commit_open(self, intent: PositionIntent, fill_price: float) -> None:
@@ -88,9 +155,51 @@ class PositionManager:
             )
             self._reserved_usdt = max(0.0, self._reserved_usdt - intent.notional_usdt)
 
+    async def close_position(self, position_key: str) -> OpenPosition | None:
+        async with self._lock:
+            return self._positions.pop(position_key, None)
+
     async def release(self, intent: PositionIntent) -> None:
         async with self._lock:
             self._reserved_usdt = max(0.0, self._reserved_usdt - intent.notional_usdt)
+
+    async def snapshot(self) -> PortfolioSnapshot:
+        async with self._lock:
+            return PortfolioSnapshot(
+                equity_usdt=self._equity_usdt,
+                reserved_usdt=self._reserved_usdt,
+                used_margin_usdt=self.used_margin_usdt,
+                open_positions=tuple(self._positions.values()),
+                strategy_heatmap=self._heatmap_locked(),
+                margin_ratio=self._margin_ratio_locked(),
+            )
+
+    @property
+    def used_margin_usdt(self) -> float:
+        return (
+            sum(position.notional_usdt for position in self._positions.values())
+            + self._reserved_usdt
+        )
+
+    @property
+    def current_exposure_usdt(self) -> float:
+        return sum(position.notional_usdt for position in self._positions.values())
+
+    def _reject_locked(
+        self, signal: TradeSignal, reason: RiskRejectionReason
+    ) -> PositionIntent | None:
+        self._last_rejection = reason
+        signal.metadata["risk_rejection_reason"] = reason.value
+        self.logger.info(
+            "risk_rejected",
+            extra={
+                "trace_id": signal.trace_id,
+                "symbol": signal.symbol,
+                "strategy": signal.strategy.value,
+                "reason": reason.value,
+            },
+        )
+        return None
 
     def _target_allocation(self, strategy: StrategyKind) -> float:
         return {
@@ -114,16 +223,51 @@ class PositionManager:
             for kind in StrategyKind
         }
 
-    def _portfolio_correlation(self, symbol: str) -> float:
+    def _portfolio_correlation_locked(self, symbol: str) -> float:
         incoming = self._return_history.get(symbol)
         if incoming is None or incoming.size < 20 or not self._positions:
             return 0.0
         correlations = []
         for position in self._positions.values():
             existing = self._return_history.get(position.symbol)
-            if existing is None or existing.size != incoming.size:
+            if existing is None:
                 continue
-            corr = np.corrcoef(incoming, existing)[0, 1]
+            length = min(incoming.size, existing.size)
+            if length < 20:
+                continue
+            left = incoming[-length:]
+            right = existing[-length:]
+            mask = np.isfinite(left) & np.isfinite(right)
+            if mask.sum() < 20:
+                continue
+            corr = np.corrcoef(left[mask], right[mask])[0, 1]
             if np.isfinite(corr):
                 correlations.append(abs(float(corr)))
         return max(correlations, default=0.0)
+
+    def _has_strategy_conflict_locked(self, signal: TradeSignal) -> bool:
+        incoming_side = (
+            Side.BUY if signal.action == SignalAction.ENTER_LONG else Side.SELL
+        )
+        for position in self._positions.values():
+            if position.symbol != signal.symbol or position.side == incoming_side:
+                continue
+            # Long-horizon position trades are authoritative. Shorter-horizon
+            # scalp/swing signals must not unwind them by opening the opposite side.
+            if (
+                position.strategy == StrategyKind.POSITION
+                or signal.strategy != StrategyKind.POSITION
+            ):
+                signal.metadata.update(
+                    {
+                        "conflicting_strategy": position.strategy.value,
+                        "conflicting_side": position.side.value,
+                    }
+                )
+                return True
+        return False
+
+    def _margin_ratio_locked(self) -> float:
+        if self._equity_usdt <= 0:
+            return 0.0
+        return self.used_margin_usdt / self._equity_usdt

--- a/tests/test_binance_perp_bot.py
+++ b/tests/test_binance_perp_bot.py
@@ -78,3 +78,72 @@ def test_position_manager_rejects_high_correlation() -> None:
         assert await manager.reserve(correlated, 100, 3) is None
 
     asyncio.run(scenario())
+
+
+def test_position_manager_rejects_scalp_against_position_conflict() -> None:
+    async def scenario() -> None:
+        manager = PositionManager(Allocation(), max_correlation=0.65)
+        await manager.update_equity(1_000)
+        position_signal = TradeSignal(
+            "BTC/USDT:USDT",
+            StrategyKind.POSITION,
+            SignalAction.ENTER_LONG,
+            0.9,
+            100,
+            RegimeMode.TREND,
+        )
+        position_intent = await manager.reserve(position_signal, 100, 3)
+        assert position_intent is not None
+        await manager.commit_open(position_intent, 100)
+
+        scalp_signal = TradeSignal(
+            "BTC/USDT:USDT",
+            StrategyKind.SCALP,
+            SignalAction.ENTER_SHORT,
+            0.9,
+            100,
+            RegimeMode.MEAN_REVERSION,
+        )
+        assert await manager.reserve(scalp_signal, 100, 3) is None
+        assert scalp_signal.metadata["risk_rejection_reason"] == "conflict"
+        assert scalp_signal.metadata["conflicting_strategy"] == "position"
+
+    asyncio.run(scenario())
+
+
+def test_position_manager_enforces_capacity_and_reports_snapshot() -> None:
+    async def scenario() -> None:
+        manager = PositionManager(
+            Allocation(), max_correlation=0.65, max_positions=1, max_margin_ratio=0.80
+        )
+        await manager.update_equity(1_000)
+        first_signal = TradeSignal(
+            "BTC/USDT:USDT",
+            StrategyKind.SCALP,
+            SignalAction.ENTER_LONG,
+            0.9,
+            100,
+            RegimeMode.TREND,
+        )
+        first = await manager.reserve(first_signal, 100, 3)
+        assert first is not None
+        await manager.commit_open(first, 100)
+
+        second_signal = TradeSignal(
+            "SOL/USDT:USDT",
+            StrategyKind.SCALP,
+            SignalAction.ENTER_LONG,
+            0.9,
+            100,
+            RegimeMode.TREND,
+        )
+        assert await manager.reserve(second_signal, 100, 3) is None
+        assert second_signal.metadata["risk_rejection_reason"] == "max_positions"
+
+        portfolio = await manager.snapshot()
+        assert portfolio.equity_usdt == 1_000
+        assert portfolio.used_margin_usdt == 100
+        assert len(portfolio.open_positions) == 1
+        assert 0 < portfolio.margin_ratio < 1
+
+    asyncio.run(scenario())


### PR DESCRIPTION
### Motivation
- Implement stronger, production-grade risk controls from the Grok spec so the multi-strategy engine is trust-minimized and race-condition safe. 
- Prevent double-spend / over-leverage by making the PositionManager the single source of truth with atomic reservation and commit semantics. 
- Enforce portfolio-level constraints (correlation, max open positions, margin ratio) and a conflict-resolution policy that protects long-horizon positions from short-horizon unwinds. 
- Improve stream orchestration to use Python 3.11+ concurrency primitives for safer lifecycle management.

### Description
- Added two new configuration parameters to `BotConfig`: `max_positions` and `max_margin_ratio` and wired them into startup wiring in `apps/backend/src/binance_perp_bot/main.py`. 
- Reworked `apps/backend/src/binance_perp_bot/risk/position_manager.py` to an atomic risk gate that includes: a `RiskRejectionReason` enum, `PortfolioSnapshot` dataclass, bounded return-history ingestion, `reserve()`/`commit_open()`/`release()` semantics, `snapshot()` and computed properties `used_margin_usdt` and `current_exposure_usdt`. 
- Implemented correlation handling that aligns unequal return windows and ignores non-finite values, and added the Grok conflict-resolution policy in `_has_strategy_conflict_locked()` so shorter-horizon opposite-side signals are rejected when they conflict with authoritative long-horizon positions. 
- Switched stream orchestration in `apps/backend/src/binance_perp_bot/main.py` to `asyncio.TaskGroup` and passed the new risk limits into `PositionManager`. 
- Added tests in `tests/test_binance_perp_bot.py` to cover high-correlation rejection, scalp-vs-position conflict rejection, capacity limits, and portfolio snapshot reporting.

### Testing
- Ran `PYTHONPATH=apps/backend/src pytest -q` and all tests passed: `11 passed`.
- Ran `ruff check apps/backend/src/binance_perp_bot tests/test_binance_perp_bot.py` and lint checks passed.
- Verified the new behavior via unit tests that assert rejection reasons and snapshot values for the upgraded risk gates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb32b44d3083219576ccc03fc0c3e1)