### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,5 +1,8 @@
 name: Lint & Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cvsz/ABTPi18n/security/code-scanning/12](https://github.com/cvsz/ABTPi18n/security/code-scanning/12)

In general, to fix this issue you should explicitly declare the `permissions` for the `GITHUB_TOKEN` in the workflow, either at the top level (applies to all jobs) or per-job. For this workflow, the job only checks out code and runs local tools; it does not need to write to the repo or interact with issues/PRs. Therefore, the best fix is to add a root-level `permissions` block with `contents: read`, which ensures the token is limited while preserving all current behavior.

Concretely, in `.github/workflows/lint-test.yml`, add a `permissions:` section near the top of the file (e.g., after `name: Lint & Test` and before the `on:` block). The block should set `contents: read`. No additional imports, methods, or other definitions are needed, and no steps need to be modified, since `actions/checkout@v4` works with a read-only `contents` permission when only reading the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
