### PR TITLE
chore: bump vulnerable deps for backend and frontend (cryptography, pillow, python-dotenv, gdown, next)

### DIFF
--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -8,10 +8,10 @@ uvicorn==0.34.0
 celery==5.4.0
 redis==5.2.1
 ccxt==4.4.48
-cryptography==46.0.5
+cryptography==46.0.7
 pydantic==2.10.6
 pydantic-settings==2.7.1
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 prisma==0.13.1
 psycopg2-binary==2.9.9
 tenacity==8.2.3
@@ -28,7 +28,7 @@ google-auth-httplib2==0.2.0
 python-telegram-bot==21.10
 # Phase 4: PromptPay and QR codes
 qrcode==8.0
-pillow==12.1.1
+pillow==12.2.0
 # Phase 4: Plugin system
 pluggy==1.6.0
 importlib-metadata==7.1.0
@@ -46,5 +46,5 @@ scikit-learn==1.6.1
 xgboost==2.1.4
 scipy==1.15.1
 # Google Drive integration and YAML config
-gdown==5.2.0
+gdown==5.2.2
 pyyaml==6.0.2

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "16.1.7",
+    "next": "16.2.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-i18next": "16.2.4",


### PR DESCRIPTION
### Motivation
- Address multiple security advisories detected in backend Python packages and a Next.js Server Components DoS advisory in the frontend by upgrading to patched releases. 
- Reduce risk from known issues in `pillow`, `cryptography`, `python-dotenv`, and `gdown`, and harden the frontend by pinning a patched `next` release. 

### Description
- Bumped backend dependency pins in `apps/backend/requirements.txt`: `cryptography` -> `46.0.7`, `python-dotenv` -> `1.2.2`, `pillow` -> `12.2.0`, and `gdown` -> `5.2.2`.
- Updated frontend Next.js pin in `apps/frontend/package.json` from `16.1.7` to `16.2.3` to incorporate the Server Components DoS fixes.
- Only dependency files were changed; no application source code or behavior was modified.

### Testing
- Ran `git diff --check` and it completed successfully. 
- Ran a dependency verification script (`python` snippet to assert the new pins and `next` version) and it completed successfully. 
- Attempted `PIP_RETRIES=0 python -m pip install --dry-run -r apps/backend/requirements.txt` which failed to locate `cryptography==46.0.7` in the environment package index. 
- Ran `node -e "const p=require('./apps/frontend/package.json'); if (p.dependencies.next !== '16.2.3') process.exit(1); console.log('frontend dependency pin verified')"` and it passed. 
- Attempted `npm install --package-lock-only --ignore-scripts --workspace apps/frontend` which failed due to registry access returning HTTP 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3f5c02788321b16814bab8e0e981)