### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/metaultra.yml
+++ b/.github/workflows/metaultra.yml
@@ -1,5 +1,8 @@
 name: MetaUltra CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cvsz/ABTPi18n/security/code-scanning/11](https://github.com/cvsz/ABTPi18n/security/code-scanning/11)

In general, the fix is to explicitly declare a restrictive `permissions` block for the workflow or for individual jobs so that the `GITHUB_TOKEN` has only the scopes required. Since this workflow only checks out the repository and runs shell scripts, it should only need read access to repository contents.

The best minimal fix here is to add `permissions: contents: read` at the top (workflow) level, just under the `name:` (or under `on:`), so it applies to all jobs, including `validate`. This matches CodeQL’s recommendation and adheres to least privilege. No other changes to steps, scripts, or configuration are required.

Concretely, in `.github/workflows/metaultra.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after line 2, before the `on:` block). No imports or additional methods are needed, since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
