### PR TITLE
Fix TradingView webhook persistence and lazy encryption key handling

### DIFF
--- a/apps/backend/src/api/tradingview_endpoints.py
+++ b/apps/backend/src/api/tradingview_endpoints.py
@@ -4,21 +4,23 @@
 // Author: ZeaZDev Meta-Intelligence (Generated) //
 // --- DO NOT EDIT HEADER --- //"""
 
+import json
 import os
 from datetime import datetime
 from logging import getLogger
-from typing import Optional
+from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException
-from prisma import Prisma
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 
 logger = getLogger(__name__)
 
 router = APIRouter()
 
-# Get Prisma instance (should be injected from main app)
-prisma = Prisma()
+# Lazily instantiate Prisma so importing this router does not require a generated
+# Prisma client. Runtime database access still fails clearly if generation has not
+# been completed.
+prisma: Any | None = None
 
 
 class TradingViewAlert(BaseModel):
@@ -52,6 +54,22 @@ class TradingViewWebhookConfig(BaseModel):
     risk_per_trade: Optional[float] = Field(
         default=1.0, description="Risk percentage per trade"
     )
+
+
+def _get_prisma() -> Any:
+    global prisma
+    if prisma is None:
+        from prisma import Prisma
+
+        prisma = Prisma()
+    return prisma
+
+
+def _model_dump(alert: TradingViewAlert) -> dict[str, Any]:
+    """Return a Pydantic v2-compatible dump with a v1 fallback."""
+    if hasattr(alert, "model_dump"):
+        return alert.model_dump()
+    return alert.dict()
 
 
 def verify_webhook_secret(
@@ -117,8 +135,9 @@ async def tradingview_webhook(
     """
     try:
         # Ensure Prisma is connected
-        if not prisma.is_connected():
-            await prisma.connect()
+        client = _get_prisma()
+        if not client.is_connected():
+            await client.connect()
 
         # Normalize action to uppercase
         action = alert.action.upper()
@@ -128,8 +147,11 @@ async def tradingview_webhook(
                 detail=f"Invalid action: {action}. Must be BUY, SELL, CLOSE, or HOLD",
             )
 
-        # Store alert in database for audit trail
-        alert_record = await prisma.tradingviewalert.create(
+        payload = _model_dump(alert)
+
+        # Store alert in database for audit trail. Field names must match the
+        # Prisma schema's camelCase identifiers, and rawPayload is a string field.
+        alert_record = await client.tradingviewalert.create(
             data={
                 "ticker": alert.ticker,
                 "exchange": alert.exchange,
@@ -137,9 +159,10 @@ async def tradingview_webhook(
                 "price": alert.price,
                 "strategy": alert.strategy or "TRADINGVIEW_ALERT",
                 "interval": alert.interval,
+                "volume": alert.volume,
                 "message": alert.message,
-                "received_at": datetime.utcnow(),
-                "raw_payload": alert.dict(),
+                "receivedAt": datetime.utcnow(),
+                "rawPayload": json.dumps(payload, default=str),
             }
         )
 
@@ -164,6 +187,8 @@ async def tradingview_webhook(
             "timestamp": datetime.utcnow().isoformat(),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(
             f"Error processing TradingView alert: {str(e)}",
@@ -171,12 +196,14 @@ async def tradingview_webhook(
         )
         raise HTTPException(
             status_code=500, detail=f"Failed to process alert: {str(e)}"
-        )
+        ) from e
 
 
 @router.get("/alerts")
 async def list_tradingview_alerts(
-    limit: int = 50, ticker: Optional[str] = None, action: Optional[str] = None
+    limit: int = Query(50, ge=1, le=500),
+    ticker: Optional[str] = None,
+    action: Optional[str] = None,
 ):
     """
     List recent TradingView alerts.
@@ -190,8 +217,9 @@ async def list_tradingview_alerts(
         List of TradingView alerts
     """
     try:
-        if not prisma.is_connected():
-            await prisma.connect()
+        client = _get_prisma()
+        if not client.is_connected():
+            await client.connect()
 
         where_clause = {}
         if ticker:
@@ -199,8 +227,8 @@ async def list_tradingview_alerts(
         if action:
             where_clause["action"] = action.upper()
 
-        alerts = await prisma.tradingviewalert.find_many(
-            where=where_clause, order={"received_at": "desc"}, take=limit
+        alerts = await client.tradingviewalert.find_many(
+            where=where_clause, order={"receivedAt": "desc"}, take=limit
         )
 
         return {
@@ -215,7 +243,7 @@ async def list_tradingview_alerts(
                     "interval": alert.interval,
                     "message": alert.message,
                     "received_at": (
-                        alert.received_at.isoformat() if alert.received_at else None
+                        alert.receivedAt.isoformat() if alert.receivedAt else None
                     ),
                 }
                 for alert in alerts
@@ -223,9 +251,13 @@ async def list_tradingview_alerts(
             "count": len(alerts),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error fetching TradingView alerts: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Failed to fetch alerts: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch alerts: {str(e)}"
+        ) from e
 
 
 @router.get("/config")

--- a/apps/backend/src/security/crypto_service.py
+++ b/apps/backend/src/security/crypto_service.py
@@ -9,24 +9,32 @@ import os
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-ENCRYPTION_KEY = os.getenv("ENCRYPTION_KEY")
-if not ENCRYPTION_KEY:
-    raise RuntimeError("ENCRYPTION_KEY not set")
 
-_raw_key = base64.b64decode(ENCRYPTION_KEY)
-if len(_raw_key) not in (16, 24, 32):
-    raise RuntimeError("ENCRYPTION_KEY must decode to 128/192/256-bit")
+def _load_key() -> bytes:
+    """Load and validate the AES-GCM key when encryption is actually used."""
+    encryption_key = os.getenv("ENCRYPTION_KEY")
+    if not encryption_key:
+        raise RuntimeError("ENCRYPTION_KEY not set")
+
+    try:
+        raw_key = base64.b64decode(encryption_key, validate=True)
+    except Exception as exc:
+        raise RuntimeError("ENCRYPTION_KEY must be valid base64") from exc
+
+    if len(raw_key) not in (16, 24, 32):
+        raise RuntimeError("ENCRYPTION_KEY must decode to 128/192/256-bit")
+    return raw_key
 
 
 def encrypt_data(plaintext: str):
-    aesgcm = AESGCM(_raw_key)
+    aesgcm = AESGCM(_load_key())
     iv = os.urandom(12)
     ct = aesgcm.encrypt(iv, plaintext.encode(), None)
     return base64.b64encode(ct).decode(), base64.b64encode(iv).decode()
 
 
 def decrypt_data(ciphertext_b64: str, iv_b64: str):
-    aesgcm = AESGCM(_raw_key)
+    aesgcm = AESGCM(_load_key())
     ciphertext = base64.b64decode(ciphertext_b64)
     iv = base64.b64decode(iv_b64)
     pt = aesgcm.decrypt(iv, ciphertext, None)

--- a/tests/test_binance_perp_bot.py
+++ b/tests/test_binance_perp_bot.py
@@ -172,3 +172,29 @@ def test_xgboost_gate_uses_cold_start_when_model_missing(tmp_path) -> None:
     assert gate.allow(snapshot(), signal)
     assert signal.metadata["ml_gate_mode"] == "calibrated_cold_start"
     assert 0 <= signal.metadata["xgb_trade_probability"] <= 1
+
+
+def test_crypto_service_imports_without_encryption_key(monkeypatch) -> None:
+    monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
+
+    from security import crypto_service
+
+    try:
+        crypto_service.encrypt_data("secret")
+    except RuntimeError as exc:
+        assert str(exc) == "ENCRYPTION_KEY not set"
+    else:
+        raise AssertionError("encrypt_data should require ENCRYPTION_KEY at call time")
+
+
+def test_crypto_service_round_trip(monkeypatch) -> None:
+    import base64
+
+    from security import crypto_service
+
+    monkeypatch.setenv("ENCRYPTION_KEY", base64.b64encode(b"1" * 32).decode())
+
+    ciphertext, iv = crypto_service.encrypt_data("secret")
+
+    assert ciphertext != "secret"
+    assert crypto_service.decrypt_data(ciphertext, iv) == "secret"

--- a/tests/test_tradingview_endpoints.py
+++ b/tests/test_tradingview_endpoints.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from api import tradingview_endpoints as endpoints
+from fastapi import HTTPException
+
+
+class DummyTradingViewAlertTable:
+    def __init__(self) -> None:
+        self.created_data = None
+        self.find_many_kwargs = None
+
+    async def create(self, data):
+        self.created_data = data
+        return SimpleNamespace(id=123)
+
+    async def find_many(self, **kwargs):
+        self.find_many_kwargs = kwargs
+        return [
+            SimpleNamespace(
+                id=123,
+                ticker="BTCUSDT",
+                exchange="binance",
+                action="BUY",
+                price=100.0,
+                strategy="TRADINGVIEW_ALERT",
+                interval="1m",
+                message="test",
+                receivedAt=datetime(2026, 5, 6, 14, 0, 0),
+            )
+        ]
+
+
+class DummyPrisma:
+    def __init__(self) -> None:
+        self.connected = False
+        self.tradingviewalert = DummyTradingViewAlertTable()
+
+    def is_connected(self):
+        return self.connected
+
+    async def connect(self):
+        self.connected = True
+
+
+@pytest.fixture()
+def dummy_prisma(monkeypatch):
+    client = DummyPrisma()
+    monkeypatch.setattr(endpoints, "prisma", client)
+    return client
+
+
+def test_tradingview_webhook_uses_schema_fields_and_json_payload(dummy_prisma):
+    alert = endpoints.TradingViewAlert(
+        ticker="BTCUSDT", action="buy", price=100.0, interval="1m", volume=12.5
+    )
+
+    result = asyncio.run(endpoints.tradingview_webhook(alert, webhook_secret="secret"))
+
+    assert result["status"] == "success"
+    data = dummy_prisma.tradingviewalert.created_data
+    assert data["action"] == "BUY"
+    assert "receivedAt" in data
+    assert "rawPayload" in data
+    assert "received_at" not in data
+    assert "raw_payload" not in data
+    assert json.loads(data["rawPayload"])["ticker"] == "BTCUSDT"
+
+
+def test_tradingview_webhook_preserves_client_errors(dummy_prisma):
+    alert = endpoints.TradingViewAlert(ticker="BTCUSDT", action="WAIT")
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(endpoints.tradingview_webhook(alert, webhook_secret="secret"))
+
+    assert exc_info.value.status_code == 400
+
+
+def test_list_tradingview_alerts_orders_by_schema_field(dummy_prisma):
+    result = asyncio.run(endpoints.list_tradingview_alerts(limit=10, ticker="BTCUSDT"))
+
+    assert result["count"] == 1
+    assert result["alerts"][0]["received_at"] == "2026-05-06T14:00:00"
+    assert dummy_prisma.tradingviewalert.find_many_kwargs["order"] == {
+        "receivedAt": "desc"
+    }


### PR DESCRIPTION
### Motivation
- Make TradingView webhook persistence align with the Prisma schema and avoid import-time failures when the Prisma client is not generated.
- Avoid forcing an `ENCRYPTION_KEY` environment variable at module import time so modules can be imported in test/dev environments and enforce key validation only when encryption is actually used.
- Add focused tests that cover TradingView persistence/ordering and crypto key behavior to prevent regressions.

### Description
- Updated `apps/backend/src/api/tradingview_endpoints.py` to lazily instantiate `Prisma` via `_get_prisma()`, JSON-serialize the raw alert payload, and use Prisma schema camelCase fields (`receivedAt`, `rawPayload`) when creating/fetching alerts; also persisted `volume` and exposed a bounded `limit` via `Query` parameters, and preserved `HTTPException` propagation for client errors.
- Added `_model_dump` helper to support Pydantic v2 (`model_dump`) with a v1 (`dict`) fallback when saving `rawPayload`.
- Changed `apps/backend/src/security/crypto_service.py` to defer `ENCRYPTION_KEY` validation to runtime via `_load_key()` so importing the module does not raise, while still validating base64 and key length (16/24/32 bytes) at call time and using `_load_key()` inside `encrypt_data`/`decrypt_data`.
- Added tests `tests/test_tradingview_endpoints.py` (new) and extended `tests/test_binance_perp_bot.py` with crypto-related checks to assert lazy key handling and correct encrypt/decrypt round-trip.

### Testing
- Ran unit tests: `python -m pytest -q` which executed the full test suite and returned `13 passed` (all tests passed).
- Ran static checks and byte-compile: `ruff check .` (auto-fixed trivial import ordering) and `python -m compileall -q apps/backend core strategies tools tests` (succeeded), both reported clean results.
- Attempted `npm install` for JS deps but it failed due to registry access returning HTTP 403 for `@types/jest` (environment/registry policy), so frontend dependency install was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4da009c48321bad2c0047f98bba3)