### PR TITLE
Make XGBoost trade gate optional and resilient to missing dependency

### DIFF
--- a/apps/backend/src/binance_perp_bot/ml/gate.py
+++ b/apps/backend/src/binance_perp_bot/ml/gate.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import logging
 from pathlib import Path
+from typing import Any
 
 import numpy as np
-import xgboost as xgb
 from binance_perp_bot.indicators import adx, atr, closes, ema, rsi
 from binance_perp_bot.models import (
     MarketSnapshot,
@@ -21,19 +23,20 @@ class XGBoostTradeGate:
         self.threshold = threshold
         self.model_path = Path(model_path)
         self.logger = logging.getLogger(__name__)
-        self.model: xgb.Booster | None = None
-        if self.model_path.exists():
-            self.model = xgb.Booster()
-            self.model.load_model(str(self.model_path))
-        else:
-            self.logger.warning(
-                "xgb_model_missing_using_calibrated_gate",
-                extra={
-                    "trace_id": "ml-gate",
-                    "symbol": "system",
-                    "strategy": "xgboost",
-                },
-            )
+        self.model: Any | None = None
+        self._xgboost: Any | None = None
+
+        if not self.model_path.exists():
+            self._log_cold_start("xgb_model_missing_using_calibrated_gate")
+            return
+
+        if importlib.util.find_spec("xgboost") is None:
+            self._log_cold_start("xgb_dependency_missing_using_calibrated_gate")
+            return
+
+        self._xgboost = importlib.import_module("xgboost")
+        self.model = self._xgboost.Booster()
+        self.model.load_model(str(self.model_path))
 
     def features(self, snapshot: MarketSnapshot, signal: TradeSignal) -> np.ndarray:
         price = closes(snapshot.ohlcv)
@@ -54,8 +57,8 @@ class XGBoostTradeGate:
         return feature_row.reshape(1, -1)
 
     def allow(self, snapshot: MarketSnapshot, signal: TradeSignal) -> bool:
-        if self.model is not None:
-            matrix = xgb.DMatrix(self.features(snapshot, signal))
+        if self.model is not None and self._xgboost is not None:
+            matrix = self._xgboost.DMatrix(self.features(snapshot, signal))
             probability = float(self.model.predict(matrix)[0])
             gate_mode = "xgboost"
         else:
@@ -64,6 +67,16 @@ class XGBoostTradeGate:
         signal.metadata["ml_gate_mode"] = gate_mode
         signal.metadata["xgb_trade_probability"] = probability
         return probability >= self.threshold
+
+    def _log_cold_start(self, message: str) -> None:
+        self.logger.warning(
+            message,
+            extra={
+                "trace_id": "ml-gate",
+                "symbol": "system",
+                "strategy": "xgboost",
+            },
+        )
 
     def _calibrated_probability(
         self, snapshot: MarketSnapshot, signal: TradeSignal


### PR DESCRIPTION
### Motivation
- Tests failed with `ModuleNotFoundError: No module named 'xgboost'` when `xgboost` is not installed, so the ML gate must not break import or runtime when the package or model file is absent.
- Provide a deterministic fallback so trading logic can run in environments without the XGBoost dependency or pre-trained model.

### Description
- Lazily load the `xgboost` package only when a model file exists and the package is present by using `importlib.util.find_spec` and `importlib.import_module` and store the module on `self._xgboost`.
- Fall back to the existing calibrated cold-start gate when the model file is missing or the `xgboost` dependency is unavailable, and attach a standardized cold-start warning via a new helper `_log_cold_start`.
- Update runtime checks to use `self._xgboost.DMatrix` when available and change model/type annotations to `Any` to avoid importing `xgboost` at module import time.

### Testing
- Ran `pytest -q` and all tests passed (`13 passed`), resolving the previous failure caused by the missing `xgboost` package.
- Ran `python -m ruff check apps/backend/src/binance_perp_bot/ml/gate.py tests/test_binance_perp_bot.py` and linting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb51e4d91c8321acdc615b68d9e58c)