### PR TITLE
Add ECC external integration descriptor and safe-by-default guide

### DIFF
--- a/docs/integrations/ECC_INTEGRATION.md
+++ b/docs/integrations/ECC_INTEGRATION.md
@@ -1,0 +1,54 @@
+# ECC Integration (affaan-m/ECC)
+
+This project supports external strategy packs under `strategies/external/`.
+Because external network access may be restricted in some runtime environments,
+this integration is designed to be **safe by default** and **manual-approval friendly**.
+
+## What was integrated
+
+- A dedicated integration descriptor was added at `strategies/external/ecc_integration.yaml`.
+- The descriptor keeps execution in dry-run mode by default.
+- No live trading is enabled automatically.
+
+## Installation
+
+1. Clone the ECC repository locally:
+
+   ```bash
+   git clone https://github.com/affaan-m/ECC.git /tmp/ECC
+   ```
+
+2. Copy the strategy files you want to use into this project:
+
+   ```bash
+   mkdir -p strategies/external/ecc
+   cp -r /tmp/ECC/* strategies/external/ecc/
+   ```
+
+3. If ECC provides Python strategy modules, make sure each strategy class:
+   - Inherits from `core.strategy_base.Strategy`
+   - Defines a unique `name`
+   - Registers itself with `StrategyRegistry.register(...)` (or relies on autoload class detection)
+
+4. Load external strategies from your startup/runtime hook:
+
+   ```python
+   from core.strategy_autoload import load_external_strategies
+
+   loaded = load_external_strategies("strategies/external/ecc")
+   print("Loaded ECC strategies:", loaded)
+   ```
+
+## Safety defaults
+
+Before enabling any ECC strategy for production:
+
+- Keep `auto_trade: false` unless an operator explicitly approves it.
+- Use paper trading/sandbox exchange credentials first.
+- Validate max position size, stop loss, and drawdown limits.
+- Ensure audit logging is active for every order event.
+
+## Notes
+
+- This integration document intentionally avoids pulling remote code automatically.
+- Manual vendor/import keeps supply-chain review explicit and auditable.

--- a/strategies/external/ecc_integration.yaml
+++ b/strategies/external/ecc_integration.yaml
@@ -1,0 +1,34 @@
+# ECC integration descriptor
+# Source repository: https://github.com/affaan-m/ECC
+# This file configures how ECC strategy assets should be interpreted by ABTPro.
+
+name: "ECC External Strategy Pack"
+description: "Integration metadata for affaan-m/ECC strategy assets"
+version: "1.0.0"
+author: "affaan-m"
+
+type: "EXTERNAL_PACKAGE"
+source:
+  repository: "https://github.com/affaan-m/ECC"
+  import_mode: "manual_review"
+  local_path: "strategies/external/ecc"
+
+execution:
+  enabled: false
+  auto_trade: false
+  mode: "dry_run"
+
+risk:
+  require_risk_manager: true
+  require_drawdown_guard: true
+  require_circuit_breaker: true
+  max_position_size: 0
+
+compliance:
+  require_audit_log: true
+  require_operator_approval: true
+
+notes: |
+  This descriptor does not execute any third-party code by itself.
+  After importing ECC files, review them and map strategy modules to
+  the internal Strategy interface before enabling runtime execution.


### PR DESCRIPTION
### Motivation
- Provide a structured, auditable way to bring in the affaan-m/ECC strategy pack without auto-fetching or auto-executing third‑party code, and to keep execution disabled until an operator reviews and approves the assets.

### Description
- Add `docs/integrations/ECC_INTEGRATION.md` with step-by-step instructions to import ECC into `strategies/external/ecc` and to load strategies using `load_external_strategies("strategies/external/ecc")`.
- Add `strategies/external/ecc_integration.yaml` as an integration descriptor that records source metadata and enforces conservative defaults (`enabled: false`, `auto_trade: false`, `mode: "dry_run"`) plus required risk and compliance checks.

### Testing
- Ran `python -m pytest -q tests/test_metaultra_example.py` and it passed (2 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16011230d0832c9dcd759af3832ce6)