### PR TITLE
Add helper script to integrate Everything-Claude-Code (ECC) repository

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -89,3 +89,20 @@ When adding new scripts:
 3. Include usage instructions
 4. Update this README with script documentation
 5. Test the script thoroughly before committing
+
+### integrate_ecc_repo.sh
+
+Integrate the Everything-Claude-Code (ECC) repository as a local external dependency.
+
+**Usage:**
+```bash
+./scripts/integrate_ecc_repo.sh
+```
+
+**Environment variables:**
+- `ECC_REPO_URL`: Git URL to clone/pull (default: `git@github.com:cvsz/everything-claude-code.git`)
+- `ECC_TARGET_DIR`: Target directory (default: `external/everything-claude-code`)
+
+**What it does:**
+- Clones ECC into `external/everything-claude-code` when missing
+- Runs `git pull --ff-only` if the repo is already present

--- a/scripts/integrate_ecc_repo.sh
+++ b/scripts/integrate_ecc_repo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ECC_REPO_URL="${ECC_REPO_URL:-git@github.com:cvsz/everything-claude-code.git}"
+ECC_TARGET_DIR="${ECC_TARGET_DIR:-external/everything-claude-code}"
+
+if [[ -d "$ECC_TARGET_DIR/.git" ]]; then
+  echo "[ECC] Repository already exists at $ECC_TARGET_DIR"
+  echo "[ECC] Pulling latest changes..."
+  git -C "$ECC_TARGET_DIR" pull --ff-only
+else
+  echo "[ECC] Cloning $ECC_REPO_URL into $ECC_TARGET_DIR"
+  mkdir -p "$(dirname "$ECC_TARGET_DIR")"
+  git clone "$ECC_REPO_URL" "$ECC_TARGET_DIR"
+fi
+
+echo "[ECC] Integration complete: $ECC_TARGET_DIR"


### PR DESCRIPTION
### Motivation
- Provide a small, reproducible helper to integrate the external Everything-Claude-Code repository into the project by cloning it or updating it in-place, with configurable overrides for environments where direct access may vary.

### Description
- Add `scripts/integrate_ecc_repo.sh` which clones `ECC_REPO_URL` into `ECC_TARGET_DIR` when missing or runs `git pull --ff-only` when present, and update `scripts/README.md` to document usage and environment variables; files changed: `scripts/integrate_ecc_repo.sh`, `scripts/README.md`.

### Testing
- Ran a shell syntax check with `bash -n scripts/integrate_ecc_repo.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160514befc832c8d07c7df26b569a4)