### PR TITLE
CI: install backend requirements in lint-test workflow

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Install Python tools
         run: |
           python -m pip install --upgrade pip
-          pip install ruff black pytest numpy pydantic
+          pip install ruff black pytest
+          pip install -r apps/backend/requirements.txt
       - name: Ruff check
         run: ruff check .
       - name: Black check


### PR DESCRIPTION
### Motivation
- Update CI workflow to install project-specific Python dependencies from `apps/backend/requirements.txt` instead of hardcoding `numpy` and `pydantic`, while keeping lint/test tools installation consistent.

### Description
- Modified `.github/workflows/lint-test.yml` to install `ruff`, `black`, and `pytest` and add `pip install -r apps/backend/requirements.txt` in the "Install Python tools" step, removing the inline `numpy` and `pydantic` installs.

### Testing
- The workflow is configured to run `ruff` (`ruff check .`), `black` (`black --check .`), and `pytest -q` as CI steps; no automated tests were executed as part of this PR preview so pass/fail results are not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1607082ce8832c844ae1385c710cbe)